### PR TITLE
Avoid hardcoding volume group name when converting images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Disclainer
+# Disclaimer
 This environment has been created for the sole purpose of providing an easy to deployment and consume Red Hat OpenShift Container Platform v3.x environment *as a sandpit*.
 
 This install will create a 'Minimal Viable Setup', which anyone can extend to

--- a/playbooks/roles/guests/tasks/main.yml
+++ b/playbooks/roles/guests/tasks/main.yml
@@ -51,7 +51,7 @@
   with_items: "{{guests}}"
 
 - name: install rhel for VMs
-  command: qemu-img convert -O raw "/var/lib/libvirt/images/{{rhel_image}}" "/dev/vg0/{{item.name}}-a"
+  command: qemu-img convert -O raw "/var/lib/libvirt/images/{{rhel_image}}" "/dev/{{volume_group}}/{{item.name}}-a"
   when: item.name not in virt_vms.list_vms
   with_items: "{{guests}}"
 - name: create vm


### PR DESCRIPTION
If using different volume group for guests, one can change it from ```group_vars/all``` but ```vg0``` was hardcoded while converting VM image to raw