### PR TITLE
Add support for version 3.7

### DIFF
--- a/playbooks/group_vars/all
+++ b/playbooks/group_vars/all
@@ -1,3 +1,4 @@
+ocp_version: 3.7
 packages:
 - wget
 - git
@@ -15,7 +16,7 @@ packages_bastion:
 repos:
 - rhel-7-server-rpms
 - rhel-7-server-extras-rpms
-- rhel-7-server-ose-3.6-rpms
+- "rhel-7-server-ose-{{ocp_version}}-rpms"
 - rhel-7-fast-datapath-rpms
 - rhel-7-server-optional-rpms
 rhel_image: rhel-kvm.qcow2

--- a/playbooks/prepare_guests.yml
+++ b/playbooks/prepare_guests.yml
@@ -23,17 +23,23 @@
     delay: 5
     when: subs_result.changed
   - name: Get pool id
-    shell: "subscription-manager list --available --matches '*Openshift*' --pool-only | tail -n 1"
-    register: poolid
-    retries: 5
-    delay: 5
-  - debug:
-      msg: |
-        "Managed to find pool id {{poolid.stdout}}"
+    block:
+      - shell: "subscription-manager list --available --matches '*Openshift*' --pool-only | tail -n 1"
+        register: poolid
+        retries: 5
+        delay: 5
+      - set_fact:
+          poolid: "{{poolid.stdout}}"
+    when: hostvars['localhost']['poolid'] is not defined
   - set_fact:
-      poolid: "{{poolid.stdout}}"
+      poolid: "{{ hostvars['localhost']['poolid'] }}"
+    when: hostvars['localhost']['poolid'] is defined
 
-- name: Register nodes to RHN and subscribe
+  - debug:
+      msg: "Managed to find pool id {{ poolid }}"
+
+
+- name: Register nodes to RHSM and subscribe
   hosts: all
   gather_facts: true
   vars_files:

--- a/playbooks/prepare_guests.yml
+++ b/playbooks/prepare_guests.yml
@@ -90,7 +90,7 @@
     with_items: "{{packages_bastion}}"
   - name: Copy playbooks to bastion
     synchronize:
-      src: /root/hetzner-ocp
+      src: ../
       dest: /root/
   - name: Copy SSH keys from host to bastion
     copy:

--- a/playbooks/roles/inventory/templates/hosts.j2
+++ b/playbooks/roles/inventory/templates/hosts.j2
@@ -37,7 +37,7 @@ openshift_docker_insecure_registries=docker-registry.default.svc,docker-registry
 # Native high availability cluster method with optional load balancer.
 #openshift_master_cluster_method=native
 openshift_master_cluster_hostname=master01
-openshift_master_cluster_public_hostname=master.{{ip_addr}}.xip.io
+openshift_master_cluster_public_hostname=master.{{ip_addr}}.nip.io
 
 
 # Configure nodeIP in the node config
@@ -79,7 +79,7 @@ openshift_examples_modify_imagestreams=true
 openshift_node_kubelet_args={'image-gc-high-threshold': ['90'], 'image-gc-low-threshold': ['80']}
 
 # default subdomain to use for exposed routes
-openshift_master_default_subdomain=apps.{{ip_addr}}.xip.io
+openshift_master_default_subdomain=apps.{{ip_addr}}.nip.io
 
 # default project node selector
 osm_default_node_selector='purpose=work'
@@ -94,9 +94,9 @@ openshift_hosted_registry_replicas=1
 # Registry Storage Options
 
 # Metrics deployment
-openshift_hosted_metrics_deploy=false
-openshift_hosted_metrics_public_url=https://metrics.apps.{{ip_addr}}.xip.io/hawkular/metrics
-openshift_metrics_hawkular_hostname=metrics.apps.{{ip_addr}}.xip.io
+openshift_metrics_install_metrics=false
+openshift_hosted_metrics_public_url=https://metrics.apps.{{ip_addr}}.nip.io/hawkular/metrics
+openshift_metrics_hawkular_hostname=metrics.apps.{{ip_addr}}.nip.io
 openshift_metrics_cassandra_replicas=1
 openshift_metrics_cassandra_limits_memory=2Gi
 openshift_metrics_hawkular_replicas=1
@@ -108,14 +108,13 @@ openshift_metrics_hawkular_nodeselector={"region":"infra"}
 openshift_metrics_heapster_nodeselector={"region":"infra"}
 
 # Logging deployment
-openshift_hosted_logging_deploy=false
 openshift_logging_install_logging=false
-openshift_logging_kibana_hostname=logging.apps.{{ip_addr}}.xip.io
+openshift_logging_kibana_hostname=logging.apps.{{ip_addr}}.nip.io
 openshift_logging_use_ops=false
 openshift_logging_master_url=master01
-openshift_logging_public_master_url=master.{{ip_addr}}.xip.io
+openshift_logging_public_master_url=master.{{ip_addr}}.nip.io
 openshift_logging_curator_default_days=7
-openshift_logging_kibana_hostname=logging.apps.{{ip_addr}}.xip.io
+openshift_logging_kibana_hostname=logging.apps.{{ip_addr}}.nip.io
 
 openshift_logging_curator_nodeselector={"region":"infra"}
 openshift_logging_es_nodeselector={"region":"infra"}

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -3,16 +3,22 @@
   hosts: localhost
   gather_facts: no
   vars_prompt:
-  - name: rhn_username
-    prompt: RHN username
+  - name: rhsm_username
+    prompt: RHSM username
     private: no
-  - name: rhn_password
-    prompt: RHN password
+  - name: rhsm_password
+    prompt: RHSM password
     private: yes
+  - name: rhsm_poolid
+    prompt: Subscription Pool ID
+    private: no
   tasks:
   - set_fact:
-      pwd: "{{rhn_password}}"
-      user: "{{rhn_username}}"
+      pwd: "{{rhsm_password}}"
+      user: "{{rhsm_username}}"
+  - set_fact:
+      poolid: "{{rhsm_poolid}}"
+    when: rhsm_poolid is defined
   - name: Create SSH key for root
     user:
       name: root


### PR DESCRIPTION
- Updated inventory and playbooks to support 3.7 by default, use nip.io for wildcard DNS for better reliability
- Use relative path for rsync to support arbitrary hetzner-ocp location and avoid hardcoded path
- Use parametric optional pool id